### PR TITLE
Add upcoming Dolomites & Corfu trips to journey timeline

### DIFF
--- a/src/Components/Journey/JourneyTimeline.jsx
+++ b/src/Components/Journey/JourneyTimeline.jsx
@@ -8,6 +8,7 @@ function JourneyTimeline({ activePointId, registerRef }) {
       case 'work': return 'work';
       case 'travel': return 'travel';
       case 'current': return 'now';
+      case 'upcoming': return 'upcoming';
       default: return '';
     }
   };
@@ -47,6 +48,16 @@ function JourneyTimeline({ activePointId, registerRef }) {
                       </span>
                     ))}
                   </div>
+                )}
+                {point.itinerary && (
+                  <a
+                    className="journey-card-itinerary-link"
+                    href={point.itinerary}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View itinerary <span className="journey-card-itinerary-arrow">→</span>
+                  </a>
                 )}
               </div>
             </div>

--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -511,6 +511,32 @@ export const journeyPoints = [
     type: 'current',
     description: 'Home in Paris again. Back to building, back to the routine I love.',
     professional: null,
+  },
+  {
+    id: 'dolomites-jul-2026',
+    city: 'Dolomites',
+    country: 'Italy',
+    geo: { lon: 12.13, lat: 46.54 },
+    get coordinates() { return geoToGrid(this.geo.lon, this.geo.lat); },
+    dateRange: '23–27 Jul 2026',
+    month: 7,
+    type: 'upcoming',
+    description: 'A clockwise loop out of Venice — east to the Tre Cime and the pale lakes, then west to Val Gardena, with two nights spent high on the mountain.',
+    itinerary: 'https://itineraries.riwashouse.live/dolomites',
+    professional: null,
+  },
+  {
+    id: 'corfu-aug-2026',
+    city: 'Corfu',
+    country: 'Greece',
+    geo: { lon: 19.92, lat: 39.62 },
+    get coordinates() { return geoToGrid(this.geo.lon, this.geo.lat); },
+    dateRange: '5–9 Aug 2026',
+    month: 8,
+    type: 'upcoming',
+    description: 'Four of us converging on one Ionian island — parents from Athens, sister from Birmingham, me from Paris — based in Dassia on the green northeast coast.',
+    itinerary: 'https://itineraries.riwashouse.live/corfu',
+    professional: null,
   }
 ];
 
@@ -523,7 +549,7 @@ export function getJourneyStats() {
     'Japan': 'Asia', 'Poland': 'Europe', 'Czech Republic': 'Europe',
     'Hungary': 'Europe', 'Austria': 'Europe', 'Denmark': 'Europe',
     'Sweden': 'Europe', 'United Kingdom': 'Europe',
-    'Netherlands': 'Europe',
+    'Netherlands': 'Europe', 'Greece': 'Europe',
   };
   journeyPoints.forEach(p => {
     if (continentMap[p.country]) continents.add(continentMap[p.country]);

--- a/src/styles.css
+++ b/src/styles.css
@@ -3039,6 +3039,16 @@ html.page-view {
   background: var(--text-secondary);
 }
 
+.journey-card-upcoming .journey-card-accent {
+  background: var(--accent-secondary);
+}
+
+/* Upcoming trips read as "planned" — dashed type label, warm accent */
+.journey-card-upcoming .journey-card-type {
+  color: var(--accent-secondary);
+  opacity: 0.9;
+}
+
 /* Card body */
 .journey-card-body {
   padding: 1rem 1.15rem;
@@ -3118,6 +3128,35 @@ html.page-view {
   color: var(--accent-primary);
   opacity: 0.5;
   font-size: 0.6rem;
+}
+
+/* "View itinerary" deep link on upcoming trip cards */
+.journey-card-itinerary-link {
+  font-family: 'Satoshi', sans-serif;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-secondary);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.55rem;
+  transition: gap 0.18s ease, opacity 0.18s ease;
+}
+
+.journey-card-itinerary-link:hover {
+  opacity: 0.8;
+  gap: 0.5rem;
+}
+
+.journey-card-itinerary-arrow {
+  transition: transform 0.18s ease;
+}
+
+.journey-card-itinerary-link:hover .journey-card-itinerary-arrow {
+  transform: translateX(2px);
 }
 
 .journey-card-desc {


### PR DESCRIPTION
## Summary
- Adds the two planned 2026 trips as **upcoming** entries on the `/journey` timeline, each deep-linking out to its page on the standalone itineraries site (`itineraries.riwashouse.live/dolomites`, `/corfu`).
- New `upcoming` card type with a warm amber accent + a "View itinerary →" external link (`target="_blank" rel="noopener noreferrer"`), matching existing card/link patterns.
- Adds Greece to the continent map so the legend stats stay accurate (now 13 countries).

## Notes
- Links point at `https://itineraries.riwashouse.live` — they go live once that Vercel project + custom domain are set up (see consolidation checklist).
- Follows the existing `journeyData.js` → `JourneyTimeline.jsx` data/render pattern; no new page or nav item (avoids colliding with the existing `< journey />`).

## Test plan
- [x] `npm run build` succeeds
- [x] `/journey` renders both upcoming cards (Dolomites, Corfu) with correct deep links, target/rel, and amber styling (verified in browser at desktop width)
- [ ] After itineraries site is deployed, confirm the two links resolve to the live itinerary pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)