### PR TITLE
Journey: Deauville arrival + upcoming Beirut homecoming

### DIFF
--- a/src/Components/Journey/DeparturesBoard.jsx
+++ b/src/Components/Journey/DeparturesBoard.jsx
@@ -50,21 +50,22 @@ function DeparturesBoard({ trips, origin, onOpen }) {
 
   const rows = trips.map((trip) => {
     const r = remark(trip);
+    const linked = !!trip.itinerary;
     return {
       key: trip.id,
-      href: trip.itinerary,
-      onClick: onOpen ? (e) => onOpen(e, trip) : undefined,
+      href: trip.itinerary || undefined,
+      onClick: linked && onOpen ? (e) => onOpen(e, trip) : undefined,
       cells: [
         { content: departDate(trip), className: 'fb-when' },
         { content: trip.city, className: 'fb-city', sub: trip.region || trip.country },
         { content: flightNo(trip), className: 'fb-flight' },
         {
-          content: (
+          content: linked ? (
             <>
               {r.text}
               <span className="fb-arrow" aria-hidden="true">→</span>
             </>
-          ),
+          ) : r.text,
           className: `fb-status fb-status-${r.kind}`,
           // Live countdown under "On time" while a trip is still ahead; the
           // departure day, mid-trip and write-up rows speak for themselves.

--- a/src/Components/Journey/FeatureItinerary.jsx
+++ b/src/Components/Journey/FeatureItinerary.jsx
@@ -1,7 +1,7 @@
 import { pad2 } from '../../Utils/ui';
 
-const ACCENT = { alpine: 'var(--jb-alpine)', sea: 'var(--jb-sea)' };
-const GLYPH = { alpine: '▲', sea: '≈' }; // ▲ peak · ≈ sea
+const ACCENT = { alpine: 'var(--jb-alpine)', sea: 'var(--jb-sea)', city: 'var(--jb-sea)' };
+const GLYPH = { alpine: '▲', sea: '≈', city: '⌂' }; // ▲ peak · ≈ sea · ⌂ home city
 
 // Poster badge per date-accurate phase. Scheduled spreads count down to the
 // departure; the day itself reads "Boarding today"; mid-trip "En route".
@@ -103,6 +103,68 @@ function SeaPoster({ uid }) {
 }
 
 /**
+ * A printed travel-poster of a Mediterranean city at dusk — Beirut: a mauve-to-gold
+ * sky over a low sun, the Mount Lebanon range hazed behind, a coastal skyline whose
+ * towers catch a few warm lit windows, and the sea laying the sun back up the water.
+ */
+function CityPoster({ uid }) {
+  return (
+    <svg viewBox="0 0 400 300" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <defs>
+        <linearGradient id={`${uid}-sky`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#26243B" />
+          <stop offset="0.45" stopColor="#64466A" />
+          <stop offset="0.76" stopColor="#C67A5E" />
+          <stop offset="1" stopColor="#EEAA5E" />
+        </linearGradient>
+        <linearGradient id={`${uid}-sea`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#C98A54" />
+          <stop offset="0.4" stopColor="#437284" />
+          <stop offset="1" stopColor="#16323E" />
+        </linearGradient>
+      </defs>
+      {/* sky */}
+      <rect width="400" height="188" fill={`url(#${uid}-sky)`} />
+      {/* low dusk sun + glow */}
+      <circle cx="256" cy="120" r="46" fill="#F6D98C" opacity="0.28" />
+      <circle cx="256" cy="122" r="26" fill="#FBE7A8" />
+      {/* Mount Lebanon — two hazy ranges behind the city */}
+      <polygon points="0,150 58,110 130,150 196,104 262,150 330,112 400,146 400,190 0,190" fill="#584359" opacity="0.55" />
+      <polygon points="0,170 66,140 140,168 214,134 288,166 356,138 400,158 400,190 0,190" fill="#3E3149" opacity="0.85" />
+      {/* sea */}
+      <rect y="184" width="400" height="116" fill={`url(#${uid}-sea)`} />
+      {/* sun laid back up the water */}
+      <polygon points="240,184 272,184 286,300 226,300" fill="#F5D488" opacity="0.22" />
+      {/* coastal skyline along the shore, in front of the ranges */}
+      <g fill="#221B29">
+        <rect x="8" y="162" width="16" height="28" />
+        <rect x="28" y="150" width="12" height="40" />
+        <rect x="44" y="168" width="20" height="22" />
+        <rect x="68" y="136" width="13" height="54" />
+        <rect x="85" y="158" width="18" height="32" />
+        <rect x="107" y="170" width="15" height="20" />
+        <rect x="126" y="154" width="12" height="36" />
+        <rect x="250" y="164" width="16" height="26" />
+        <rect x="268" y="146" width="12" height="44" />
+        <rect x="284" y="168" width="20" height="22" />
+        <rect x="308" y="150" width="13" height="40" />
+        <rect x="325" y="166" width="17" height="24" />
+        <rect x="346" y="172" width="16" height="18" />
+        <rect x="366" y="158" width="12" height="32" />
+      </g>
+      {/* warm lit windows at dusk */}
+      <g fill="#F4C56B">
+        <rect x="72" y="144" width="2.4" height="3" /><rect x="76" y="152" width="2.4" height="3" /><rect x="72" y="160" width="2.4" height="3" />
+        <rect x="31" y="156" width="2.4" height="3" /><rect x="35" y="166" width="2.4" height="3" />
+        <rect x="271" y="154" width="2.4" height="3" /><rect x="275" y="164" width="2.4" height="3" />
+        <rect x="311" y="158" width="2.4" height="3" /><rect x="315" y="168" width="2.4" height="3" />
+        <rect x="129" y="160" width="2.4" height="3" />
+      </g>
+    </svg>
+  );
+}
+
+/**
  * One documented itinerary as a large editorial spread: body (index, city,
  * meta, tagline, stop chips, CTA) beside a printed travel-poster "plate".
  * Alternating layouts (`alt`) flip the columns. A date-accurate badge counts the
@@ -111,7 +173,7 @@ function SeaPoster({ uid }) {
  * links to the live itinerary; onOpen washes the screen in the trip's palette first.
  */
 function FeatureItinerary({ trip, index, alt, phase = 'documented', days = 0, onOpen }) {
-  const theme = trip.theme === 'sea' ? 'sea' : 'alpine';
+  const theme = trip.theme === 'sea' || trip.theme === 'city' ? trip.theme : 'alpine';
   const upcoming = phase !== 'documented';
   const hasItinerary = !!trip.itinerary;
   const regionLabel = (trip.region || trip.country).replace(' · ', ' / ');
@@ -152,7 +214,7 @@ function FeatureItinerary({ trip, index, alt, phase = 'documented', days = 0, on
         )}
       </div>
       <div className="jb-fplate">
-        {theme === 'sea' ? <SeaPoster uid={uid} /> : <AlpinePoster uid={uid} />}
+        {theme === 'sea' ? <SeaPoster uid={uid} /> : theme === 'city' ? <CityPoster uid={uid} /> : <AlpinePoster uid={uid} />}
         <span className={`jb-fstatus jb-fstatus-${phase}`}>
           {upcoming && <span className="jb-fstatus-dot" aria-hidden="true" />}
           {badgeText(phase, days)}

--- a/src/Components/Journey/FeatureItinerary.jsx
+++ b/src/Components/Journey/FeatureItinerary.jsx
@@ -113,23 +113,24 @@ function SeaPoster({ uid }) {
 function FeatureItinerary({ trip, index, alt, phase = 'documented', days = 0, onOpen }) {
   const theme = trip.theme === 'sea' ? 'sea' : 'alpine';
   const upcoming = phase !== 'documented';
+  const hasItinerary = !!trip.itinerary;
   const regionLabel = (trip.region || trip.country).replace(' · ', ' / ');
   const stops = trip.stops || [];
   const uid = `fp${index}`;
 
   return (
     <a
-      className={`jb-feature${alt ? ' jb-feature-alt' : ''}`}
-      href={trip.itinerary}
+      className={`jb-feature${alt ? ' jb-feature-alt' : ''}${hasItinerary ? '' : ' jb-feature-static'}`}
+      href={hasItinerary ? trip.itinerary : undefined}
       style={{ '--jb-accent': ACCENT[theme] }}
-      onClick={onOpen ? (e) => onOpen(e, trip) : undefined}
+      onClick={hasItinerary && onOpen ? (e) => onOpen(e, trip) : undefined}
     >
       <div className="jb-fbody">
         <div className="jb-findex">{pad2(index + 1)} — {regionLabel}</div>
         <h3 className="jb-fcity">{trip.city}</h3>
         <div className="jb-fmeta">
           <span>{trip.kind}</span><span className="jb-d" aria-hidden="true" />
-          <span>{trip.nights} nights</span><span className="jb-d" aria-hidden="true" />
+          {trip.nights ? (<><span>{trip.nights} nights</span><span className="jb-d" aria-hidden="true" /></>) : null}
           <span>{trip.dateRange}</span>
         </div>
         <p className="jb-ftagline">{trip.description}</p>
@@ -140,11 +141,15 @@ function FeatureItinerary({ trip, index, alt, phase = 'documented', days = 0, on
             ))}
           </div>
         )}
-        <span className="jb-fcta">
-          {upcoming ? 'See the plan' : 'Read the itinerary'}
-          <span className="jb-line" aria-hidden="true" />
-          <span className="jb-arrow" aria-hidden="true">{'→'}</span>
-        </span>
+        {hasItinerary ? (
+          <span className="jb-fcta">
+            {upcoming ? 'See the plan' : 'Read the itinerary'}
+            <span className="jb-line" aria-hidden="true" />
+            <span className="jb-arrow" aria-hidden="true">{'→'}</span>
+          </span>
+        ) : (
+          <span className="jb-fcta jb-fcta-static">Going home</span>
+        )}
       </div>
       <div className="jb-fplate">
         {theme === 'sea' ? <SeaPoster uid={uid} /> : <AlpinePoster uid={uid} />}

--- a/src/Components/Journey/JourneyBoard.jsx
+++ b/src/Components/Journey/JourneyBoard.jsx
@@ -39,6 +39,7 @@ function JourneyBoard() {
 
   // Wash the screen in the trip's palette, then hand off to the live itinerary.
   const handleOpen = useCallback((e, trip) => {
+    if (!trip.itinerary) return; // a write-up-less trip (e.g. a homecoming) isn't a link
     if (prefersReducedMotion()) return; // let the <a href> navigate normally
     e.preventDefault();
     setDeparting(trip);

--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -512,6 +512,18 @@ export const journeyPoints = [
     professional: null,
   },
   {
+    id: 'deauville-jun-2026',
+    city: 'Deauville',
+    country: 'France',
+    geo: { lon: 0.07, lat: 49.36 },
+    get coordinates() { return geoToGrid(this.geo.lon, this.geo.lat); },
+    dateRange: 'Jun 2026',
+    month: 6,
+    type: 'travel',
+    description: 'A day on the Normandy coast — the long boardwalk, striped parasols, and the grey-green Channel. Oysters and sea air, an hour from Paris.',
+    professional: null,
+  },
+  {
     id: 'dolomites-jul-2026',
     city: 'Dolomites',
     country: 'Italy',
@@ -560,6 +572,29 @@ export const journeyPoints = [
     theme: 'sea',
     stops: ['Dassia', 'Old Town', 'Paleokastritsa', "Canal d'Amour"],
     mrz: 'P<GRCCORFU<<DASSIA<<<<<<<<<<<<<<<0508CFU<<4N',
+  },
+  {
+    id: 'beirut-jul-2026',
+    city: 'Beirut',
+    country: 'Lebanon',
+    geo: { lon: 35.5, lat: 33.9 },
+    get coordinates() { return geoToGrid(this.geo.lon, this.geo.lat); },
+    dateRange: '11 Jul 2026',
+    month: 7,
+    type: 'upcoming',
+    description: 'Heading home for the summer — family, the Mediterranean, and the food I miss most. No plan this time, just Beirut.',
+    // A homecoming, not a written-up trip — it rides the Departures board and its
+    // date-accurate countdown, then folds back into the Beirut base once the day passes.
+    itinerary: null,
+    professional: null,
+    kind: 'Homecoming',
+    region: 'Lebanon · Home',
+    depart: 'Jul 11',
+    code: 'LB',
+    iata: 'BEY',
+    startDate: '2026-07-11',
+    endDate: '2026-07-11',
+    theme: 'sea',
   }
 ];
 
@@ -592,7 +627,7 @@ const IATA = {
   Tokyo: 'HND', Osaka: 'KIX', Kyoto: 'UKY', Nara: 'NAR', 'Mt Fuji': 'NGO',
   Warsaw: 'WAW', Prague: 'PRG', Budapest: 'BUD', Krakow: 'KRK', Vienna: 'VIE',
   Copenhagen: 'CPH', 'Malmö': 'MMX', London: 'LHR', Strasbourg: 'SXB',
-  Amsterdam: 'AMS', Dolomites: 'VCE', Corfu: 'CFU',
+  Amsterdam: 'AMS', Dolomites: 'VCE', Corfu: 'CFU', Deauville: 'DOL',
 };
 
 export function iataFor(city) {
@@ -623,15 +658,15 @@ function daysToDeparture(startDate, iso) {
   return Math.max(0, Math.round((Date.parse(startDate) - Date.parse(iso)) / DAY_MS));
 }
 
-// The featured spread is the live slate only: itinerary trips still ahead or in
-// progress, soonest departure first. Once a trip's dates pass it graduates out of
-// here and into the Arrivals ledger (below), so a finished trip is never shown
-// twice. Carrying an itinerary link no longer pins a trip here — that's now just
-// an optional link any stay can have, so older trips can be written up too.
+// The featured spread is the live slate only: any dated trip (one carrying a
+// start/end window) still ahead or in progress, soonest departure first. Once a
+// trip's dates pass it graduates out of here and into the Arrivals ledger (below),
+// so a finished trip is never shown twice. A written-up itinerary is optional — a
+// trip with no write-up (e.g. a homecoming) still rides the board and its countdown.
 export function getFeaturedItineraries(today = new Date()) {
   const iso = today.toISOString().slice(0, 10);
   return journeyPoints
-    .filter((p) => p.itinerary && tripPhase(p, iso) !== 'documented')
+    .filter((p) => p.startDate && p.endDate && tripPhase(p, iso) !== 'documented')
     .map((p) => ({
       ...p,
       phase: tripPhase(p, iso),
@@ -649,7 +684,7 @@ export function getArrivalsLedger(today = new Date()) {
   // featured departure (an itinerary trip not yet past its dates) or otherwise
   // still upcoming; the moment it's documented it graduates in here. Older trips
   // that gain an itinerary link stay put and simply become clickable rows.
-  const isLiveFeature = (p) => p.itinerary && tripPhase(p, iso) !== 'documented';
+  const isLiveFeature = (p) => p.startDate && p.endDate && tripPhase(p, iso) !== 'documented';
   const isFutureUpcoming = (p) => p.type === 'upcoming' && !(p.endDate < iso);
   const arrived = journeyPoints.filter((p) => !isLiveFeature(p) && !isFutureUpcoming(p));
 

--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -594,7 +594,7 @@ export const journeyPoints = [
     iata: 'BEY',
     startDate: '2026-07-11',
     endDate: '2026-07-11',
-    theme: 'sea',
+    theme: 'city',
   }
 ];
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3262,6 +3262,11 @@ body.journey-page .footer-text { color: var(--jb-ink-soft); }
 .jb-feature:hover .jb-fcta .jb-arrow { transform: translateX(8px); }
 .jb-fcta .jb-line { flex: 1; height: 1px; background: var(--jb-line-2); min-width: 28px; transition: background 0.4s ease; }
 .jb-feature:hover .jb-fcta .jb-line { background: var(--jb-accent); }
+/* A featured trip with no write-up (e.g. a homecoming) rides the board but isn't a
+   link — default cursor, a muted non-arrowed label, and no hover lift on its plate. */
+.jb-feature-static { cursor: default; }
+.jb-feature-static:hover .jb-fplate svg { transform: none; }
+.jb-fcta-static { color: var(--jb-muted); }
 
 /* the printed travel-poster "plate" */
 .jb-fplate {


### PR DESCRIPTION
## Summary

Adds two trips to the journey board:

- **Deauville** (Jun 2026) — a simple **landed stop**: appears in Arrivals, the world map, and the city stats (Cities 22 → 23). Adds `Deauville → DOL` to the IATA map.
- **Beirut** (Sat **11 Jul 2026**) — an **upcoming Departure home**. It has no written itinerary, so this teaches the board to carry a **write-up-less departure**: `getFeaturedItineraries` now keys off a start/end **date window** instead of requiring an itinerary link, and the Departures row + feature card degrade gracefully — no link/arrow/wash, CTA reads **"Going home"**, nights hidden. It rides the date-accurate countdown ("Departs in 5 days" today), flips to **"Boarding"** on the 11th, then folds back into the Beirut base.

Journeys' existing trips (Dolomites, Corfu) are unchanged — they keep their itinerary links and `→` affordance.

> **Copy note:** the two trip descriptions ("A day on the Normandy coast…", "Heading home for the summer…") are my draft wording — tweak them to your voice anytime.

## Test Plan

- [x] `npm run build` → 5 pages, `[build] Complete!`
- [x] Departures (both themes): Beirut is the soonest row, static (no link/arrow), "On time · in 5d"; Dolomites/Corfu still link
- [x] Now Boarding: Beirut card = "Departs in 5 days", "Going home", "Homecoming · 11 Jul 2026", non-link
- [x] Arrivals: Deauville present; Beirut held out until the 11th
- [x] Ticker "NEXT UP: BEIRUT ✦ DOLOMITES ✦ CORFU"; stats show 23 cities
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)