### PR TITLE
Fix: poster-plate labels vanishing in light mode

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3270,6 +3270,10 @@ body.journey-page .footer-text { color: var(--jb-ink-soft); }
 
 /* the printed travel-poster "plate" */
 .jb-fplate {
+  /* The plate is always a dark image (dark bg + dusk/alpine/sea poster), so pin its
+     "screen ink" to the light value in BOTH themes. Otherwise the corner labels
+     (status pill, IATA, coordinates) inherit the light-substrate dark ink and vanish. */
+  --jb-screen-rgb: 244, 236, 220;
   position: relative; border-radius: 5px; overflow: hidden; min-height: 320px;
   background: #1C2430;
   border: 1px solid var(--jb-line);


### PR DESCRIPTION
## Summary

On `/journey` in **light mode**, the poster-plate corner labels — the status pill (e.g. "Departs in 4 days"), the IATA code, and the coordinates — were **invisible**. The plate is always a dark image (dark background + the dusk / alpine / sea poster art), but those labels coloured themselves with `rgb(var(--jb-screen-rgb))`, which resolves to the light substrate's **dark ink** in light mode → dark text on a dark plate.

**Fix:** pin `--jb-screen-rgb` to its light value *within* `.jb-fplate`, so the plate's "screen ink" stays light in both themes (the plate is conceptually an always-on dark screen). One scoped override covers the status pill, IATA, coordinates, and the inset shadow. Dark mode is unchanged (identical value).

Affects all three departure cards (Beirut, Dolomites, Corfu).

## Test Plan

- [x] `npm run build` → 5 pages, `[build] Complete!`
- [x] Light mode: badge / IATA / coordinates now render `rgb(244,236,220)` (light) on every plate — verified visually + computed styles
- [x] Dark mode: unchanged (`rgb(244,236,220)`, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)