### PR TITLE
Spectral typeface + human-voiced copy (no em dashes)

### DIFF
--- a/src/Components/About.jsx
+++ b/src/Components/About.jsx
@@ -440,7 +440,7 @@ public class AtmosphericController : MonoBehaviour {
                     eyebrow="whoami"
                     title="About"
                     stats={[
-                        { label: 'Lebanese–Canadian' },
+                        { label: 'Lebanese-Canadian' },
                         { label: 'Based in Paris' },
                     ]}
                     live="SWE @ Mistral"

--- a/src/Components/Journey/TerminalHeader.jsx
+++ b/src/Components/Journey/TerminalHeader.jsx
@@ -7,7 +7,7 @@ const MONS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OC
 /**
  * The terminal header — the airport identity strip that opens the page:
  * a mono ID strip (RIWA HOTEIT INTL · RWA + live HH:MM:SS clock and date),
- * the Fraunces "Journeys." title, a stats readout with the live "now" ping,
+ * the Spectral "Journeys." title, a stats readout with the live "now" ping,
  * and a scrolling LED ticker of the lead line + boarding call.
  */
 function TerminalHeader({ stats, currentCity, boarding = [], upcoming = [] }) {

--- a/src/Components/PageMasthead.jsx
+++ b/src/Components/PageMasthead.jsx
@@ -14,7 +14,7 @@ const MONS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OC
  *
  * @param {string} section  right-hand system id, e.g. "WORKLOG" (rendered upper)
  * @param {string} [eyebrow] small mono kicker above the title
- * @param {string} [title]   Fraunces display word (a trailing "." dot is added)
+ * @param {string} [title]   Spectral display word (a trailing "." dot is added)
  * @param {Array<{value?:string,label:string}>} [stats]  stat cells
  * @param {string} [live]    optional live-pip label, e.g. "Now at Mistral"
  * @param {boolean} [compact] slim variant — system line only (no title/stats)

--- a/src/Components/ProjectsAndBlog.jsx
+++ b/src/Components/ProjectsAndBlog.jsx
@@ -39,7 +39,7 @@ function ProjectsAndBlog() {
         {
             id: 2,
             title: "Beirut: LLM assistant backend",
-            description: "Service that answers user queries about venues and menus using an LLM. Handles prompt building, retrieval, and response shaping for the mobile client.",
+            description: "A backend that answers questions about venues and menus using an LLM. I handled the prompt building, retrieval, and shaping the responses for the mobile app.",
             technologies: ["node.js", "typescript", "openai", "express"],
             image: "/Images/beirut-llm.png",
             codeLink: "https://github.com/riwaht/beirut-chatbot-llm-proj"
@@ -47,7 +47,7 @@ function ProjectsAndBlog() {
         {
             id: 3,
             title: "Notion ↔ Revolut server",
-            description: "Sync + automation service that mirrors financial events into Notion and surfaces Notion data into workflows. Built the endpoints, webhooks, and schema mapping.",
+            description: "A sync and automation service that mirrors financial events into Notion and pulls Notion data back into my workflows. I built the endpoints, webhooks, and schema mapping.",
             technologies: ["node.js", "express", "notion api", "revolut api", "webhooks"],
             image: "/Images/notion-revolut.png",
             codeLink: "https://github.com/riwaht/notion-revolut-server"
@@ -55,7 +55,7 @@ function ProjectsAndBlog() {
         {
             id: 4,
             title: "Portfolio (3D + web)",
-            description: "Your current 3D house experience plus the new multi-page site structure. Built with React/Three.js and a clean content layer for case studies.",
+            description: "The 3D house experience plus this new multi-page site. Built with React and Three.js, with a clean content layer for the case studies.",
             technologies: ["react", "three.js", "r3f", "vite"],
             image: "/Images/MainScreen.png",
             codeLink: "https://github.com/riwaht/portfolio-2.0"
@@ -93,7 +93,7 @@ function ProjectsAndBlog() {
             date: "March 2026",
             readTime: "4 min read",
             tags: ["AI", "Mistral"],
-            excerpt: "Spaces is an internal platform tool that scaffolds projects, manages dev environments, and enables deployments. This post explores how designing a CLI to work with both human developers and AI agents led to better developer experience overall.",
+            excerpt: "Spaces is an internal platform tool that scaffolds projects, manages dev environments, and handles deployments. I wrote about what it was like designing a CLI for both human developers and AI agents, and how building for both ended up making the whole thing better to use.",
             externalUrl: "https://mistral.ai/news/spaces",
             variant: "mistral"
         },
@@ -103,7 +103,7 @@ function ProjectsAndBlog() {
             date: "June 2025",
             readTime: "5 min read",
             tags: ["Game Development", "Technical"],
-            excerpt: "I've been working on a narrative-driven puzzle-platformer inspired by Inside, Limbo, and Fahrenheit 451. Instead of dialogue, the game tells its story through movement, puzzles, and environments. Here's a look at how I'm building a world where silence speaks louder than words.",
+            excerpt: "I've been working on a narrative-driven puzzle-platformer inspired by Inside, Limbo, and Fahrenheit 451. Instead of dialogue, the game tells its story through movement, puzzles, and environments. Here's how I'm building a world where silence does most of the talking.",
             content: `
                 <h2>The Vision</h2>
                 <p>The idea was simple: build a game where the story unfolds without a single line of dialogue. Inspired by titles like <em>Inside</em> and <em>Limbo</em>, and layered with the emotional weight of <em>Fahrenheit 451</em>, I wanted to create a platformer where silence, atmosphere, and the player's imagination become the narrative engine.</p>
@@ -153,7 +153,7 @@ function ProjectsAndBlog() {
             excerpt: "Ever wished your bank transactions could automatically sync to Notion? I built a small FastAPI backend that links TrueLayer and Notion to give me complete control over how my financial data is categorized and visualized.",
             content: `
               <h2>The Problem</h2>
-              <p>As someone who tracks everything in Notion — from tasks to goals to even memories — managing my expenses separately through banking apps never felt complete. I wanted my financial transactions to show up in Notion automatically, categorized, converted, and ready to analyze.</p>
+              <p>As someone who tracks everything in Notion, from tasks to goals to even memories, managing my expenses separately through banking apps never felt complete. I wanted my financial transactions to show up in Notion automatically, categorized, converted, and ready to analyze.</p>
           
               <h2>The Solution</h2>
               <p>I built a FastAPI backend that connects to my bank via <a href="https://truelayer.com" target="_blank">TrueLayer</a> (I use Revolut) and syncs transactions to Notion. The system handles categorization, multi-currency conversion, and supports multiple bank accounts with ease.</p>
@@ -197,10 +197,10 @@ function ProjectsAndBlog() {
               </ul>
           
               <h2>The Result</h2>
-              <p>Every day, my Notion workspace updates with the latest transactions — no more manual copying or guessing where my money went. It's simple, fast, and tailored to my setup.</p>
+              <p>Every day, my Notion workspace updates with the latest transactions. No more manual copying or guessing where my money went. It's simple, fast, and tailored to my setup.</p>
           
               <h2>What I Learned</h2>
-              <p>This project reminded me how powerful small automation tools can be. By combining a few APIs and keeping the system modular, I built something I actually use every day. I'm deliberately keeping the scope limited — no bloated dashboards or 3rd-party dependencies — but I'm always open to suggestions or improvements.</p>
+              <p>This project reminded me how powerful small automation tools can be. By combining a few APIs and keeping the system modular, I built something I actually use every day. I'm deliberately keeping the scope limited, no bloated dashboards or 3rd-party dependencies, but I'm always open to suggestions or improvements.</p>
           
               <p>It's still a work in progress, but it's already saved me hours of tracking and budgeting time. If you like automating personal finance or organizing everything in Notion like I do, feel free to check it out or reach out!</p>
             `
@@ -214,7 +214,7 @@ function ProjectsAndBlog() {
             excerpt: "Before APIs, internships, or even proper side projects, there was one chaotic Discord bot. It was my very first coding project, built with Discord4J, and it taught me more about reading documentation (and patience) than anything else.",
             content: `
                 <h2>The Context</h2>
-                <p>Back when I started, there was no ChatGPT I could ask for help. It was just me, a Java library called <strong>Discord4J</strong>, and about four short subpages of documentation with tiny examples. No walkthroughs, no deep explanations—just enough to say, "Good luck."</p>
+                <p>Back when I started, there was no ChatGPT I could ask for help. It was just me, a Java library called <strong>Discord4J</strong>, and about four short subpages of documentation with tiny examples. No walkthroughs, no deep explanations, just enough to say, "Good luck."</p>
         
                 <h2>Learning by Chaos</h2>
                 <p>I had no clue what I was doing. So I did the only thing I could: <em>fuck around and find out</em>. I copy-pasted, broke things, fixed them, broke them again. Slowly, I started to understand how event-driven code worked.</p>
@@ -233,7 +233,7 @@ function ProjectsAndBlog() {
                 <p>It wasn't much, but when that message appeared in the server, I felt unstoppable. I had just written code that <em>talked back to me</em>.</p>
         
                 <h2>Why It Stuck</h2>
-                <p>What made this project special wasn't the code itself, but the feeling. For the first time, I realized that I could use programming to replace myself—to literally automate my presence in a Discord server and have a bot talk to my friends for me. That was hilarious, but also strangely powerful.</p>
+                <p>What made this project special wasn't the code itself, but the feeling. For the first time, I realized that I could use programming to replace myself, to literally automate my presence in a Discord server and have a bot talk to my friends for me. That was hilarious, but also strangely powerful.</p>
         
                 <h2>What It Taught Me</h2>
                 <ul>
@@ -243,7 +243,7 @@ function ProjectsAndBlog() {
                 </ul>
         
                 <h2>Looking Back</h2>
-                <p>That Discord bot wasn't impressive. It was clunky, barely useful, and honestly kind of spammy. But it was the first time I felt the spark—that <em>this</em> is what I want to keep doing. And honestly, that spark is still here today.</p>
+                <p>That Discord bot wasn't impressive. It was clunky, barely useful, and honestly kind of spammy. But it was the first time I felt the spark, that <em>this</em> is what I want to keep doing. And honestly, that spark is still here today.</p>
         
                 <p><em>If I could add a gif here, it would be the bot happily spamming "Hello world" in chat while my friends begged me to turn it off.</em></p>
             `

--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -96,7 +96,7 @@ export const journeyPoints = [
     dateRange: 'Feb 2025',
     month: 2,
     type: 'travel',
-    description: 'A trip I had been planning for years. Wandered through Tokyo: Shibuya, Akihabara, Shinjuku -- every neighborhood a different world.',
+    description: 'A trip I had been planning for years. Wandered through Tokyo: Shibuya, Akihabara, Shinjuku. Every neighborhood felt like its own little world.',
     professional: null,
   },
   {
@@ -206,7 +206,7 @@ export const journeyPoints = [
     dateRange: 'Aug 2025',
     month: 8,
     type: 'travel',
-    description: 'Thermal baths and ruin bars. Budapest has an energy like no other city -- half historic grandeur, half underground cool.',
+    description: 'Thermal baths and ruin bars. Budapest has an energy like no other city, half historic grandeur and half underground cool.',
     professional: null,
   },
   {
@@ -472,7 +472,7 @@ export const journeyPoints = [
     dateRange: 'May 2026',
     month: 5,
     type: 'travel',
-    description: 'A quick London trip. Strolled through Hyde Park and ate incredible Chinese and Indian food, then went to Code with Claude on May 20 -- made some amazing connections there.',
+    description: 'A quick London trip. Strolled through Hyde Park and ate incredible Chinese and Indian food, then went to Code with Claude on May 20 and made some amazing connections there.',
     professional: null,
   },
   {
@@ -496,7 +496,7 @@ export const journeyPoints = [
     dateRange: 'May 2026',
     month: 5,
     type: 'travel',
-    description: 'Four days in Amsterdam with my boyfriend. Wandered the canals, the Van Gogh Museum, and the NEMO Science Museum -- then watched Harry Styles live, a dream I had been holding onto for years.',
+    description: 'Four days in Amsterdam with my boyfriend. Wandered the canals, the Van Gogh Museum, and the NEMO Science Museum, then watched Harry Styles live, a dream I had been holding onto for years.',
     professional: null,
   },
   {
@@ -520,7 +520,7 @@ export const journeyPoints = [
     dateRange: 'Jun 2026',
     month: 6,
     type: 'travel',
-    description: 'A day on the Normandy coast — the long boardwalk, striped parasols, and the grey-green Channel. Oysters and sea air, an hour from Paris.',
+    description: 'A day trip to the Normandy coast. The long boardwalk, the striped parasols, oysters, and sea air, an hour from Paris.',
     professional: null,
   },
   {
@@ -532,7 +532,7 @@ export const journeyPoints = [
     dateRange: '23–27 Jul 2026',
     month: 7,
     type: 'upcoming',
-    description: 'A clockwise loop out of Venice — east to the Tre Cime and the pale lakes, then west to Val Gardena, with two nights spent high on the mountain.',
+    description: 'A loop out of Venice by car. East to the Tre Cime and the pale lakes first, then west to Val Gardena, with two nights spent up on the mountain.',
     itinerary: 'https://itineraries.riwashouse.live/dolomites',
     professional: null,
     kind: "Couple's road trip",
@@ -557,7 +557,7 @@ export const journeyPoints = [
     dateRange: '5–9 Aug 2026',
     month: 8,
     type: 'upcoming',
-    description: 'Four of us converging on one Ionian island — parents from Athens, sister from Birmingham, me from Paris — based in Dassia on the green northeast coast.',
+    description: 'Four of us meeting on one Ionian island. My parents coming in from Athens, my sister from Birmingham, me from Paris, all of us based in Dassia on the green northeast coast.',
     itinerary: 'https://itineraries.riwashouse.live/corfu',
     professional: null,
     kind: 'Family trip',
@@ -582,7 +582,7 @@ export const journeyPoints = [
     dateRange: '11 Jul 2026',
     month: 7,
     type: 'upcoming',
-    description: 'Heading home for the summer — family, the Mediterranean, and the food I miss most. No plan this time, just Beirut.',
+    description: 'Heading home for the summer. Family, the sea, and the food I miss most. No plan this time, just Beirut.',
     // A homecoming, not a written-up trip — it rides the Departures board and its
     // date-accurate countdown, then folds back into the Beirut base once the day passes.
     itinerary: null,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const { title, description, image, url, type, bodyClass } = Astro.props;
   <link rel="icon" type="image/svg+xml" href="/house-icon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..900;1,9..144,400..900&family=Spline+Sans+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Spline+Sans+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
   <SEO title={title} description={description} image={image} url={url} type={type} />
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,6 @@
 :root {
-  /* Typography — Fraunces is the site-wide signature face, Spline Sans Mono for data */
-  --font-sans: 'Fraunces', Georgia, 'Times New Roman', serif;
+  /* Typography: Spectral is the site-wide signature face, Spline Sans Mono for data */
+  --font-sans: 'Spectral', Georgia, 'Times New Roman', serif;
   --font-mono: 'Spline Sans Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
   /* Light substrate — a warm printed-paper timetable */


### PR DESCRIPTION
## Summary

Two changes you asked for:

**1. New signature face: Spectral** (was Fraunces). Calmer, more established editorial serif that still suits the printed-timetable / terminal feel and reads cleanly at body sizes too. One variable drives the whole site, so it's a clean swap: `--font-sans` + the Google Fonts load. (Chosen live via the font picker; picker was a throwaway and isn't in this PR.)

**2. Humanized copy, zero em dashes.** Removed every em dash / `--` aside from the visible copy and rewrote the AI-flavoured bits in a plainer, first-person voice — **keeping every fact**. I matched each section's existing register (journey descriptions stay sentence-case; the About stays lowercase), rather than forcing one style.
- **Journey:** de-AI'd the featured trips (Dolomites, Corfu) and the two I'd written (Beirut, Deauville); dropped the `--` asides in Tokyo / Budapest / London / Amsterdam. Most other trip blurbs were already yours and were left alone.
- **Work:** made the impersonal project blurbs first-person, fixed a tell-tale "**Your current** 3D house experience…" AI artifact, and de-marketed the Spaces + game blog excerpts.
- **About:** `Lebanese-Canadian` hyphen (was an en dash).

## One thing left for you

The **long blog-post bodies** (Notion↔Revolut, the game post, the Discord-bot post) I only **de-dashed** — I didn't fully rewrite them, since those are personal essays and you'll want your own voice there (the Discord one already reads very "you"). Want me to rewrite those too, or will you take them?

## Test Plan

- [x] `npm run build` → 5 pages, `[build] Complete!`
- [x] Spectral renders site-wide (verified `--font-sans` + `.th-h1` computed font, light + dark)
- [x] Content em-dash sweep: clean
- [ ] Skim the reworded copy and tweak anything that doesn't sound like you

🤖 Generated with [Claude Code](https://claude.com/claude-code)