### PR TITLE
fix(pottery): anchor the shelf and intro to the masthead column

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -161,13 +161,17 @@
 }
 
 /* ===================== POTTERY — kiln shelf + field notes ===================== */
-.pot-intro {
-  width: min(1180px, 92vw); margin: clamp(18px, 3vw, 30px) auto 0;
-  font-family: var(--font-sans); color: var(--text-secondary); font-size: 1.05rem; line-height: 1.6; max-width: 62ch;
+/* intro + shelf share the masthead's content column so nothing floats: full-width
+   container, left-aligned inner block starting at the same edge as the title/stats */
+.pot-intro { width: min(1180px, 92vw); margin: clamp(18px, 3vw, 30px) auto 0; }
+.pot-intro p {
+  margin: 0; max-width: 62ch;
+  font-family: var(--font-sans); color: var(--text-secondary); font-size: 1.05rem; line-height: 1.6;
 }
-.pot-shelf-wrap { width: min(680px, 94vw); margin: clamp(22px, 4vw, 40px) auto clamp(40px, 6vw, 72px); position: relative; z-index: 1; }
-/* the shelves sit straight on the page (no panel), spaced well apart, pots on top */
-.pot-studio { position: relative; display: flex; flex-direction: column; gap: clamp(34px, 6.5vw, 62px); }
+.pot-shelf-wrap { width: min(1180px, 92vw); margin: clamp(22px, 4vw, 40px) auto clamp(40px, 6vw, 72px); position: relative; z-index: 1; }
+/* the shelves sit straight on the page (no panel), spaced well apart, pots on top;
+   the studio is a left-aligned block so the shelf anchors to the content edge */
+.pot-studio { position: relative; display: flex; flex-direction: column; gap: clamp(34px, 6.5vw, 62px); max-width: 700px; }
 .pot-level { position: relative; z-index: 1; display: flex; flex-direction: column; }
 .pot-level-pots {
   position: relative; z-index: 2;


### PR DESCRIPTION
## Summary
The /pottery shelf was its own `min(680px)` block centered on the page, so it floated in the middle aligned to neither the masthead nor the intro. The intro had the same problem (a centered 62ch column, indented).

This puts the shelf and intro in the same `min(1180px, 92vw)` content column as the masthead and left-aligns their inner blocks, so the title, stats, intro, and shelf all share one left edge. The pots sit at the left and the open shelf space to the right reads as room to grow.

## Test Plan
- [x] `npm run build` passes (6 pages)
- [x] Masthead, intro, and shelf left edges align (all at the same content-column edge)
- [x] Verified in both light and dark themes