### PR TITLE
fix(footer): left-align the footer to the content column

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1888,19 +1888,21 @@ button:disabled:hover {
 .footer {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
-  padding: 3rem 2rem 2rem;
-  text-align: center;
+  padding: 3rem 0 2rem;
+  text-align: left;
   transition: all 0.3s ease;
 }
 
+/* the footer shares the masthead's content column and left-aligns, so it reads as
+   part of the page instead of a block floating in the dead centre */
 .footer-content {
-  max-width: 1200px;
+  width: min(1180px, 92vw);
   margin: 0 auto;
 }
 
 .social-links {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 2rem;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
The site footer was fully centered (`text-align: center` + a centered social-icon row) while every page's masthead is left-anchored, so the icons and copyright clustered in the dead centre of the page — looking like a block floating in the middle.

This aligns the footer to the same `min(1180px, 92vw)` content column as the masthead and left-aligns its contents, so the icons and copyright start at the same left edge as the page title and stats.

Global change (the footer is shared across all pages). The journey-page footer overrides only touch colors, so they're unaffected.

## Test Plan
- [x] `npm run build` passes (6 pages)
- [x] Footer icons + copyright align to the masthead's left edge (47px, matching `.pm-id`) on `/pottery` and `/`
- [x] Verified in both light and dark themes