### PR TITLE
fix(footer): pin the footer to the bottom on short pages

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1891,6 +1891,9 @@ button:disabled:hover {
   padding: 3rem 2rem 2rem;
   text-align: center;
   transition: all 0.3s ease;
+  /* the page-container is a min-height:100vh flex column; this soaks up any
+     leftover space so a short page's footer sits at the bottom, not mid-page */
+  margin-top: auto;
 }
 
 .footer-content {


### PR DESCRIPTION
## Summary
On short pages (e.g. `/pottery`), the footer sat partway down the page with empty background below it, instead of at the bottom of the viewport. The `.page-container` is already a `min-height: 100vh` flex column, but nothing absorbed the leftover vertical space.

Adding `margin-top: auto` to `.footer` soaks up the free space and pins the footer to the bottom. The footer stays centered; on pages whose content already exceeds the viewport it simply sits after the content as before.

## Test Plan
- [x] `npm run build` passes (6 pages)
- [x] Tall viewport (1040×1450): footer bottom = viewport bottom, no gap below (`margin-top: auto` pushes it down)
- [x] Native desktop: footer bottom = page bottom, page fills 100vh
- [x] Footer remains centered (`justify-content: center`, `text-align: center`)
- [x] Verified in light and dark themes