### PR TITLE
Count two more pots off the wheel, not yet glazed

### DIFF
--- a/src/Utils/potteryData.js
+++ b/src/Utils/potteryData.js
@@ -98,7 +98,7 @@ export const potteryPieces = [
 // photographed) earn a spot on the shelf above and appear in `potteryPieces`;
 // this counts everything thrown, including pieces still drying or unglazed.
 // Bump it as more come out of the kiln.
-export const potsThrown = 8;
+export const potsThrown = 10;
 
 // Little kiln-log stats for the masthead. `pieces` is everything thrown;
 // `finished` is how many made it onto the shelf.


### PR DESCRIPTION
Bumps `potsThrown` from 8 to 10 for two pieces that are thrown but still waiting on glaze.

They count toward the total without earning a spot on the shelf, so the `/pottery` masthead now reads **10 pieces** and the intro reads "10 pots off the wheel so far. The 5 that made it all the way through glazing and firing…". The shelf itself is unchanged.

One file touched: `src/Utils/potteryData.js`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAZmAqZH5q27GpWUzcT66i)_