### PR TITLE
Hide the Apr 2026 Paris base row from the arrivals board

### DIFF
--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -839,6 +839,7 @@ const RETURN_STUB_IDS = new Set([
   'warsaw-after-paris',
   'warsaw-return-2025',
   'paris-after-strasbourg',
+  'paris-apr-2026',
   'paris-after-london-may-2026',
 ]);
 


### PR DESCRIPTION
`paris-apr-2026` ("Back in Paris. Building, exploring, living.") is a return-to-base row, not a trip, so it shouldn't appear as an arrival on the journey board.

Adds it to `RETURN_STUB_IDS` in `src/Utils/journeyData.js` — the same mechanism already used for the other "back to base" entries. It stays in `journeyPoints` so the map route's return-to-Paris leg is preserved, but it no longer shows as a board row.

After: Paris reads Sep 2018 · Nov 2025 · Dec 2025 · Dec 2025 · Feb 2026 · NOW (43 rows total, down from 44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENZbgPS4TtbyLyEYq9PvaG)_