### PR TITLE
Add a July 2023 Paris trip to the journey board

### DIFF
--- a/src/Utils/journeyData.js
+++ b/src/Utils/journeyData.js
@@ -136,6 +136,18 @@ export const journeyPoints = [
     professional: null,
   },
   {
+    id: 'paris-jul-2023',
+    city: 'Paris',
+    country: 'France',
+    geo: { lon: 2.35, lat: 48.9 },
+    get coordinates() { return geoToGrid(this.geo.lon, this.geo.lat); },
+    dateRange: 'Jul 2023',
+    month: 7,
+    type: 'travel',
+    description: 'A summer trip to Paris.',
+    professional: null,
+  },
+  {
     id: 'athens-2023',
     city: 'Athens',
     country: 'Greece',


### PR DESCRIPTION
Adds a `paris-jul-2023` travel entry to `journeyPoints`, placed with the July 2023 trips. It shows as a "Jul 2023 · Paris" arrival row.

The description is intentionally ordinal-free ("A summer trip to Paris.") — the existing Paris entries say "Second time" (Nov 2025) and "Third time" (Dec 2025), and a 2023 visit falls chronologically before those, so I didn't want to add a conflicting count. Happy to renumber those descriptions if you'd like the ordinals to stay consistent.

After: Paris reads Sep 2018 · Jul 2023 · Nov 2025 · Dec 2025 · Dec 2025 · Feb 2026 · NOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENZbgPS4TtbyLyEYq9PvaG)_